### PR TITLE
Add support for $('input, select') just like serialize(), brackets in names and duplicate checkboxes

### DIFF
--- a/example-includes/js/example-scripts.js
+++ b/example-includes/js/example-scripts.js
@@ -2,10 +2,20 @@ function Compare() {
     var serializeResults = $("form[name='testForm']").serialize();
     var serializeAllResults = $("form[name='testForm']").serializeAll();
 
-    $("#results").html(
-        "<p><strong>.serialize() output...</strong></p>" +
+    $("#results").append(
+        "<p><strong>$('form').serialize() output...</strong></p>" +
         "<p class=\"red\">" + serializeResults + "</p>" +
-        "<p><strong>.serializeAll() output...</strong></p>" +
+        "<p><strong>$('form').serializeAll() output...</strong></p>" +
+        "<p class=\"green\">" + serializeAllResults + "</p>"
+    );
+
+    serializeResults = $("input, select").serialize();
+    serializeAllResults = $("input, select").serializeAll();
+
+    $("#results").append(
+        "<p><strong>$('input, select').serialize() output...</strong></p>" +
+        "<p class=\"red\">" + serializeResults + "</p>" +
+        "<p><strong>$('input, select').serializeAll() output...</strong></p>" +
         "<p class=\"green\">" + serializeAllResults + "</p>"
     );
 }

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
             <p>Some regular fields, that would work with just <a href="https://api.jquery.com/serialize/">.serialize()</a></p>
             <div>
                 <label for="textField">Text</label>
-                <input type="text" name="textField" id="textField" value="example text">
+                <input type="text" name="product[textField]" id="textField" value="example text">
             </div>
 
             <div>
@@ -33,7 +33,8 @@
 
             <div>
                 <label for="checkboxField">Checkbox (checked)</label>
-                <input type="checkbox" name="checkboxField" id="checkboxField" value="cbvalue" checked>
+                <input type="hidden" name="product[checkboxField]" id="uncheckboxField" value="0">
+                <input type="checkbox" name="product[checkboxField]" id="checkboxField" value="cbvalue" checked>
             </div>
 
             <div>


### PR DESCRIPTION
Thank you for this plugin!

1. While testing it in my usecases, I found it lacking compatibility with the original `jquery.serialize()`.   
I frequently select specific inputs to be serialized by class or names, but `$('input').serializeAll()` never got different results :)
3. I also use input names with brackets, e.g.: `product[name]`, `product[art_nr]`.   
While checking for duplicates, the names must be url encoded first.
4. And I use a framework that prepends checkboxes with a hidden input and an 'uncheck value', which is always posted.   
The value is overruled when the checkbox is checked (using php on server side). So also `input` should be checked for duplicates.
5. Instead of looping I used `indexOf` to check for duplicates and return early if the field is duplicate.

The changed `index.html` and `example-script.js` are untested (yikes)